### PR TITLE
updated init.pp to take in a custom path for denyhosts cfg/conf file

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -27,6 +27,7 @@ class denyhosts (
   $deny_threshold_valid = '10',
   $deny_threshold_root = '1',
   $deny_threshold_restricted = '1',
+  $denyhosts_cfg = '/etc/denyhosts.conf',
   $work_dir = '/var/lib/denyhosts',
   $suspicious_login_report_allowed_hosts = 'YES',
   $hostname_lookup = 'YES',
@@ -66,7 +67,7 @@ class denyhosts (
 
   package { 'denyhosts': ensure => $version }
 
-  file { '/etc/denyhosts.conf':
+  file { $denyhosts_cfg:
     owner   => root,
     group   => root,
     mode    => '0644',


### PR DESCRIPTION
updated denyhosts to take a custom path of where denyhosts.conf can live.

Repoforge's denyhosts config file lives in /etc/denyhosts/denyhosts.cfg. I made this small modification so I can specify an alternate path to ensure the denyhosts file to the same place /etc/denyhosts/denyhosts.cfg vs what is hard configured in /etc/denyhosts.conf.

cheers!
